### PR TITLE
fix: harden OAuth login flow and secure token storage permissions

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import open from "open";
 import http from "http";
+import crypto from "crypto";
 import { URLSearchParams } from "url";
 import { saveConfig } from "../utils/config";
 
@@ -12,47 +13,7 @@ export const command = "login";
 export const description = "Log into Harvest";
 export const builder = {};
 
-export const handler = async (): Promise<void> => {
-  const server = http
-    .createServer(async (req, res) => {
-      const queryString = req.url?.split("?")[1] || "";
-      const params = new URLSearchParams(queryString);
-
-      const error = params.get("error");
-      if (error) {
-        console.error(chalk.red(error));
-      } else {
-        const accessToken = params.get("access_token");
-        const scope = params.get("scope");
-
-        if (accessToken && scope?.match(/^harvest:\d+$/)) {
-          await saveConfig({
-            accessToken,
-            accountId: scope.split(":")[1],
-          });
-          console.log(
-            chalk.green("Success! You are now authenticated with Harvest."),
-          );
-        } else {
-          console.error(
-            chalk.red("Error getting access token and account id."),
-          );
-        }
-      }
-
-      res.write(LOGIN_HTML);
-      res.end();
-
-      req.socket.end();
-      req.socket.destroy();
-      server.close();
-    })
-    .listen(PORT);
-
-  open(
-    `${BASE_URL}/oauth2/authorize?client_id=${CLIENT_ID}&response_type=token`,
-  );
-};
+const LOGIN_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 const LOGIN_HTML = `<!DOCTYPE html>
 <html lang="en">
@@ -87,3 +48,65 @@ const LOGIN_HTML = `<!DOCTYPE html>
     </main>
   </body>
 </html>`;
+
+export const handler = async (): Promise<void> => {
+  const state = crypto.randomBytes(16).toString("hex");
+
+  const server = http
+    .createServer(async (req, res) => {
+      const queryString = req.url?.split("?")[1] || "";
+      const params = new URLSearchParams(queryString);
+
+      const error = params.get("error");
+      if (error) {
+        console.error(chalk.red("Authentication error."));
+      } else {
+        const returnedState = params.get("state");
+        if (returnedState !== state) {
+          console.error(chalk.red("Invalid state parameter. Login aborted."));
+          res.write(LOGIN_HTML);
+          res.end();
+          req.socket.end();
+          req.socket.destroy();
+          server.close();
+          return;
+        }
+
+        const accessToken = params.get("access_token");
+        const scope = params.get("scope");
+
+        if (accessToken && scope?.match(/^harvest:\d+$/)) {
+          await saveConfig({
+            accessToken,
+            accountId: scope.split(":")[1],
+          });
+          console.log(
+            chalk.green("Success! You are now authenticated with Harvest."),
+          );
+        } else {
+          console.error(
+            chalk.red("Error getting access token and account id."),
+          );
+        }
+      }
+
+      res.write(LOGIN_HTML);
+      res.end();
+
+      req.socket.end();
+      req.socket.destroy();
+      server.close();
+    })
+    .listen(PORT, "localhost");
+
+  const timeout = setTimeout(() => {
+    server.close();
+    console.error(chalk.red("Login timed out. Please try again."));
+  }, LOGIN_TIMEOUT_MS);
+
+  server.on("close", () => clearTimeout(timeout));
+
+  open(
+    `${BASE_URL}/oauth2/authorize?client_id=${CLIENT_ID}&response_type=token&state=${state}`,
+  );
+};

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -35,9 +35,12 @@ export async function saveConfig(config: Partial<Config>): Promise<void> {
     await fs.promises.writeFile(
       await configPath(),
       JSON.stringify(Object.assign({}, existingConfig, config)),
+      { mode: 0o600 },
     );
   } catch (error) {
-    await fs.promises.writeFile(await configPath(), JSON.stringify(config));
+    await fs.promises.writeFile(await configPath(), JSON.stringify(config), {
+      mode: 0o600,
+    });
   }
 }
 
@@ -45,7 +48,7 @@ async function configPath(): Promise<string> {
   const dir = path.join(ospath.home(), ".hrvst");
 
   if (!fs.existsSync(dir)) {
-    await fs.promises.mkdir(dir);
+    await fs.promises.mkdir(dir, { mode: 0o700 });
   }
 
   return path.join(dir, "config.json");


### PR DESCRIPTION
## Summary

While reviewing the codebase before use, I found a few security issues worth addressing:

- **CSRF protection**: The OAuth authorization URL had no `state` parameter, leaving the callback open to cross-site request forgery. This PR generates a cryptographically random state value, includes it in the authorization URL, and validates it in the callback before processing any tokens.
- **Localhost binding**: The callback HTTP server was listening on all interfaces (`0.0.0.0`) rather than explicitly on `localhost`. The exposure window is brief, but there's no reason to accept connections from non-loopback addresses.
- **Login timeout**: The callback server would wait indefinitely if the user closed the browser without completing auth. Added a 5-minute timeout after which the server closes and an error is shown.
- **Error output sanitization**: The raw `error` parameter from the OAuth redirect was previously echoed directly to stderr. Replaced with a fixed string to avoid printing arbitrary server-controlled content.
- **Config file permissions**: `~/.hrvst/config.json` (which stores the OAuth access token) was written without explicit permissions, leaving it world-readable on systems with a permissive umask. Now written with `mode: 0o600` and the parent directory created with `mode: 0o700`.

## Test plan

- [ ] `hrvst login` opens browser and completes auth successfully
- [ ] Verify `~/.hrvst/config.json` is created with `600` permissions (`ls -la ~/.hrvst/`)
- [ ] Verify `~/.hrvst/` directory has `700` permissions
- [ ] Tamper with the `state` param in the callback URL — CLI should abort with "Invalid state parameter"
- [ ] Let the login prompt sit for 5+ minutes without completing — CLI should exit with timeout message